### PR TITLE
removed bug in getImgIds()

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -191,8 +191,8 @@ class COCO:
             ids = self.imgs.keys()
         else:
             ids = set(imgIds)
-            for catId in catIds:
-                if len(ids) == 0:
+            for i, catId in enumerate(catIds):
+                if i == 0 and len(ids) == 0:
                     ids = set(self.catToImgs[catId])
                 else:
                     ids &= set(self.catToImgs[catId])


### PR DESCRIPTION
getImgIds(catIds) starts accumulating imgIds from scratch, even after a subset of catIds yields no common imgIds.

Here is code that reproduces the bug:
```
from pycocotools.coco import COCO

dataDir='..'
dataType='val2014'
annFile='%s/annotations/instances_%s.json'%(dataDir,dataType)

coco=COCO(annFile)

categories = ['skateboard', 'bear']          
catIds = coco.getCatIds(catNms=categories)
print len(coco.getImgIds(catIds=catIds)) # output = 0

categories = ['skateboard', 'bear', 'tie']          
catIds = coco.getCatIds(catNms=categories)
print len(coco.getImgIds(catIds=catIds)) # output = 1092
```