### PR TITLE
Minor bug in _mask.pyx

### DIFF
--- a/PythonAPI/pycocotools/_mask.pyx
+++ b/PythonAPI/pycocotools/_mask.pyx
@@ -287,5 +287,5 @@ def frPyObjects(pyobj, siz h, w):
     elif type(pyobj) == list and type(pyobj[0]) == dict:
         objs = frUncompressedRLE(pyobj, h, w)
     else:
-        raise 'input type is not supported.'
+        raise Exception('input type is not supported.')
     return objs


### PR DESCRIPTION
Without the fix one receives `TypeError: raise: exception class must be a subclass of BaseException` instead of the intended message.