### PR TITLE
Need luaopen function to satisfy MSVC.

### DIFF
--- a/LuaAPI/rocks/coco-scm-1.rockspec
+++ b/LuaAPI/rocks/coco-scm-1.rockspec
@@ -26,7 +26,7 @@ build = {
     ["coco.MaskApi"] = "LuaAPI/MaskApi.lua",
     ["coco.CocoApi"] = "LuaAPI/CocoApi.lua",
     libmaskapi = {
-      sources = { "common/maskApi.c" },
+      sources = { "common/maskApi.c", "common/luaopen.c" },
       incdirs = { "common/" }
     }
   }

--- a/common/luaopen.c
+++ b/common/luaopen.c
@@ -1,0 +1,5 @@
+#include <lua.h>
+#ifdef _MSC_VER
+/* Allows building with MS compilers */
+int luaopen_libmaskapi(lua_State *L) { return 0; }
+#endif


### PR DESCRIPTION
The COCO API currently doesn't build with MSVC, which expects a function called luaopen_libmaskapi to be exported by the library. This adds it.