### PR TITLE
Fix loadRes() to work with both Python 2 and 3.

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -300,7 +300,12 @@ class COCO:
 
         print('Loading and preparing results...')
         tic = time.time()
-        if type(resFile) == str or type(resFile) == unicode:
+        # Check result type in a way compatible with Python 2 and 3.
+        try:
+            is_string =  isinstance(resFile, basestring)  # Python 2
+        except NameError:
+            is_string = isinstance(resFile, str)  # Python 3
+        if is_string:
             anns = json.load(open(resFile))
         elif type(resFile) == np.ndarray:
             anns = self.loadNumpyAnnotations(resFile)


### PR DESCRIPTION
This is a small fix for issue #49 to let loadRes() work on Python 2 & 3.