### PR TITLE
add and use _isArrayLike in PythonAPI

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -62,6 +62,14 @@ if PYTHON_VERSION == 2:
 elif PYTHON_VERSION == 3:
     from urllib.request import urlretrieve
 
+
+def _isArrayLike(obj):
+    if hasattr(obj, '__iter__') and hasattr(obj, '__len__'):
+        return True
+    else:
+        return False
+
+
 class COCO:
     def __init__(self, annotation_file=None):
         """
@@ -130,8 +138,8 @@ class COCO:
                iscrowd (boolean)       : get anns for given crowd label (False or True)
         :return: ids (int array)       : integer array of ann ids
         """
-        imgIds = imgIds if type(imgIds) == list else [imgIds]
-        catIds = catIds if type(catIds) == list else [catIds]
+        imgIds = imgIds if _isArrayLike(imgIds) else [imgIds]
+        catIds = catIds if _isArrayLike(catIds) else [catIds]
 
         if len(imgIds) == len(catIds) == len(areaRng) == 0:
             anns = self.dataset['annotations']
@@ -157,9 +165,9 @@ class COCO:
         :param catIds (int array)  : get cats for given cat ids
         :return: ids (int array)   : integer array of cat ids
         """
-        catNms = catNms if type(catNms) == list else [catNms]
-        supNms = supNms if type(supNms) == list else [supNms]
-        catIds = catIds if type(catIds) == list else [catIds]
+        catNms = catNms if _isArrayLike(catNms) else [catNms]
+        supNms = supNms if _isArrayLike(supNms) else [supNms]
+        catIds = catIds if _isArrayLike(catIds) else [catIds]
 
         if len(catNms) == len(supNms) == len(catIds) == 0:
             cats = self.dataset['categories']
@@ -178,8 +186,8 @@ class COCO:
         :param catIds (int array) : get imgs with all given cats
         :return: ids (int array)  : integer array of img ids
         '''
-        imgIds = imgIds if type(imgIds) == list else [imgIds]
-        catIds = catIds if type(catIds) == list else [catIds]
+        imgIds = imgIds if _isArrayLike(imgIds) else [imgIds]
+        catIds = catIds if _isArrayLike(catIds) else [catIds]
 
         if len(imgIds) == len(catIds) == 0:
             ids = self.imgs.keys()
@@ -198,7 +206,7 @@ class COCO:
         :param ids (int array)       : integer ids specifying anns
         :return: anns (object array) : loaded ann objects
         """
-        if type(ids) == list:
+        if _isArrayLike(ids):
             return [self.anns[id] for id in ids]
         elif type(ids) == int:
             return [self.anns[ids]]
@@ -209,7 +217,7 @@ class COCO:
         :param ids (int array)       : integer ids specifying cats
         :return: cats (object array) : loaded cat objects
         """
-        if type(ids) == list:
+        if _isArrayLike(ids):
             return [self.cats[id] for id in ids]
         elif type(ids) == int:
             return [self.cats[ids]]
@@ -220,7 +228,7 @@ class COCO:
         :param ids (int array)       : integer ids specifying img
         :return: imgs (object array) : loaded img objects
         """
-        if type(ids) == list:
+        if _isArrayLike(ids):
             return [self.imgs[id] for id in ids]
         elif type(ids) == int:
             return [self.imgs[ids]]

--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -64,10 +64,7 @@ elif PYTHON_VERSION == 3:
 
 
 def _isArrayLike(obj):
-    if hasattr(obj, '__iter__') and hasattr(obj, '__len__'):
-        return True
-    else:
-        return False
+    return hasattr(obj, '__iter__') and hasattr(obj, '__len__')
 
 
 class COCO:


### PR DESCRIPTION
When I was trying to use the coco's python api for the first time I came across this unnecessary limitation. The way to fix it is very simple, so I created this pull request.

## The limitation
When calling functions such as `loadImgs` you are supposed to pass pass an argument called `ids`, in the code there is this bit which checks whether `ids` is a list of numbers or a single number:
````python
if type(ids) == list
````
When I was using the function I was doing something like this

````python
cat_ids = coco.getCatIds(catNms=['person', 'dog', 'skateboard'])
img_ids = coco.getImgIds(catIds=cat_ids)
imgs = coco.loadImgs(ids=np.random.choice(img_ids, size=2)) # loading 2 random images from the set
````
But it didn't work, since `ids` was expected to be a list and my input was `numpy.ndarray`.

So I looked into the code and found no reason to limit `ids` to be a list since the code only needs `len(ids)` and `for x in ids` to work. And numpy arrays have both those capabilities.

So this was my attempt to remove this limitation.