### PR TITLE
fix loadAnns() for python2 long type

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -205,7 +205,10 @@ class COCO:
         """
         if _isArrayLike(ids):
             return [self.anns[id] for id in ids]
-        elif type(ids) == int:
+        if PYTHON_VERSION == 2:
+            if type(ids) == int or type(ids) == long:
+                return [self.anns[ids]]
+        elif PYTHON_VERSION == 3 and type(ids) == int:
             return [self.anns[ids]]
 
     def loadCats(self, ids=[]):


### PR DESCRIPTION
Integer type in python2 includes int and long,while python3 unified to one type: int.
So loadAnns() return None when pass long type.
fixed this problem by condition of python version.