### PR TITLE
exclude string type from _isArrayLike test

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -64,7 +64,7 @@ elif PYTHON_VERSION == 3:
 
 
 def _isArrayLike(obj):
-    return hasattr(obj, '__iter__') and hasattr(obj, '__len__')
+    return hasattr(obj, '__iter__') and hasattr(obj, '__len__') and type(obj).__name__!="str"
 
 
 class COCO:


### PR DESCRIPTION
It prevent the 'str' type from passing the _isArrayLike test. Otherwise, some class will be considered as subclass of a wrong superclass. 
E.g. "car" -> "vehicle", "cat" -> "non-vehicle".   "car" will be classified as a subclass of both "vehicle" and "non-vehicle" by member function coco.getCatIds(self, catNums=[], supNms=[], catIds=[]); because "vehicle" is in "non-vehicle".  

