### PR TITLE
getAnnIds: areaRng not inclusive of limits

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -238,7 +238,7 @@ class COCO:
         """
         if len(anns) == 0:
             return 0
-        if 'segmentation' in anns[0] or 'keypoints' in anns[0]:
+        if 'bbox' in anns[0] or 'segmentation' in anns[0] or 'keypoints' in anns[0]:
             datasetType = 'instances'
         elif 'caption' in anns[0]:
             datasetType = 'captions'
@@ -252,6 +252,12 @@ class COCO:
             color = []
             for ann in anns:
                 c = (np.random.random((1, 3))*0.6+0.4).tolist()[0]
+                if 'bbox' in ann and 'segmentation' not in ann:
+                    [bbox_x, bbox_y, bbox_w, bbox_h] = ann['bbox']
+                    poly = [[bbox_x, bbox_y], [bbox_x, bbox_y+bbox_h], [bbox_x+bbox_w, bbox_y+bbox_h], [bbox_x+bbox_w, bbox_y]]
+                    np_poly = np.array(poly).reshape((4,2))
+                    polygons.append(Polygon(np_poly))
+                    color.append(c)
                 if 'segmentation' in ann:
                     if type(ann['segmentation']) == list:
                         # polygon

--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -225,9 +225,9 @@ class COCO:
         :param ids (int array)       : integer ids specifying img
         :return: imgs (object array) : loaded img objects
         """
-        if _isArrayLike(ids):
+        if _isArrayLike(ids) and not isinstance(ids, str):
             return [self.imgs[id] for id in ids]
-        elif type(ids) == int:
+        elif type(ids) == int or isinstance(ids, str):
             return [self.imgs[ids]]
 
     def showAnns(self, anns, ax=None):

--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -147,7 +147,7 @@ class COCO:
             else:
                 anns = self.dataset['annotations']
             anns = anns if len(catIds)  == 0 else [ann for ann in anns if ann['category_id'] in catIds]
-            anns = anns if len(areaRng) == 0 else [ann for ann in anns if ann['area'] > areaRng[0] and ann['area'] < areaRng[1]]
+            anns = anns if len(areaRng) == 0 else [ann for ann in anns if ann['area'] >= areaRng[0] and ann['area'] < areaRng[1]]
         if not iscrowd == None:
             ids = [ann['id'] for ann in anns if ann['iscrowd'] == iscrowd]
         else:

--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -230,7 +230,7 @@ class COCO:
         elif type(ids) == int:
             return [self.imgs[ids]]
 
-    def showAnns(self, anns):
+    def showAnns(self, anns, ax=None):
         """
         Display the specified annotations.
         :param anns (array of object): annotations to display
@@ -245,7 +245,8 @@ class COCO:
         else:
             raise Exception('datasetType not supported')
         if datasetType == 'instances':
-            ax = plt.gca()
+            if ax is None:
+                ax = plt.gca()
             ax.set_autoscale_on(False)
             polygons = []
             color = []

--- a/README.txt
+++ b/README.txt
@@ -13,3 +13,7 @@ To install:
 -For Matlab, add coco/MatlabApi to the Matlab path (OSX/Linux binaries provided)
 -For Python, run "make" under coco/PythonAPI
 -For Lua, run “luarocks make LuaAPI/rocks/coco-scm-1.rockspec” under coco/
+
+
+If you wish to install pycocotools directly from this github repository, simply use the following command 
+`pip install "git+https://github.com/ashnair1/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI"`


### PR DESCRIPTION
If you were to query annotations within a particular area range, via the `getAnnIds` function, it ignores those objects that have areas equal to the limits.

For example,

```
# Assuming objects areas only lie between 10^2 and 1e5^2 pixels

areaRng = [10,32,64,96]

small    = len(ann.getAnnIds(areaRng=[(areaRng[0]**2) , areaRng[1]**2]))
medium   = len(ann.getAnnIds(areaRng=[(areaRng[1]**2) , areaRng[2]**2]))
large    = len(ann.getAnnIds(areaRng=[(areaRng[2]**2) , areaRng[3]**2]))
total = len(ann.getAnnIds(areaRng=[(areaRng[0]**2), (areaRng[3]**2)]))

assert total = small + medium + large
```
The assertion would fail if there are objects that have area **exactly equal to** 10^2, 32^2, 64^2 or 96 ^2 pixels.