### PR TITLE
Create pyproject.toml

### DIFF
--- a/PythonAPI/pyproject.toml
+++ b/PythonAPI/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["cython","numpy","setuptools>=40.8.0","wheel"]

--- a/PythonAPI/pyproject.toml
+++ b/PythonAPI/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["cython","numpy","setuptools>=40.8.0","wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The pycocotools package in PyPi fails with the message:
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-0x2vz55i/pycocotools/setup.py", line 2, in <module>
        from Cython.Build import cythonize
    ModuleNotFoundError: No module named 'Cython'

This might be a possible solution, needs a bit of testing though.