### PR TITLE
Add functions to compute inverse mask in RLE representation

### DIFF
--- a/LuaAPI/MaskApi.lua
+++ b/LuaAPI/MaskApi.lua
@@ -29,6 +29,7 @@ Usage:
   keep   = MaskApi.nms( dt, thr )
   a      = MaskApi.area( Rs )
   Rs     = MaskApi.invert( Rs )
+  Rs     = MaskApi.crop( Rs, bbox )
   bbs    = MaskApi.toBbox( Rs )
   Rs     = MaskApi.frBbox( bbs, h, w )
   R      = MaskApi.frPoly( poly, h, w )
@@ -149,6 +150,15 @@ MaskApi.toBbox = function( Rs )
   libmaskapi.rleToBbox(Qs,bb:data(),n)
   MaskApi._rlesFree(Qs,n)
   return bb
+end
+
+MaskApi.crop = function( Rs, bbox )
+  local Qs, n, h, w = MaskApi._rlesFrLua(Rs)
+  local bb = bbox:type('torch.IntTensor'):contiguous():data()
+  local Ms = MaskApi._rlesInit(n)
+  libmaskapi.rleCrop(Qs[0],Ms[0],n,bb)
+  MaskApi._rlesFree(Qs,n)
+  return MaskApi._rlesToLua(Ms,n)
 end
 
 MaskApi.frBbox = function( bbs, h, w )

--- a/LuaAPI/MaskApi.lua
+++ b/LuaAPI/MaskApi.lua
@@ -13,6 +13,7 @@ The following API functions are defined:
   iou    - Compute intersection over union between masks.
   nms    - Compute non-maximum suppression between ordered masks.
   area   - Compute area of encoded masks.
+  invert - Compute inverse of encoded masks.
   toBbox - Get bounding boxes surrounding encoded masks.
   frBbox - Convert bounding boxes to encoded masks.
   frPoly - Convert polygon to encoded mask.
@@ -27,6 +28,7 @@ Usage:
   o      = MaskApi.iou( dt, gt, [iscrowd=false] )
   keep   = MaskApi.nms( dt, thr )
   a      = MaskApi.area( Rs )
+  Rs     = MaskApi.invert( Rs )
   bbs    = MaskApi.toBbox( Rs )
   Rs     = MaskApi.frBbox( bbs, h, w )
   R      = MaskApi.frPoly( poly, h, w )
@@ -131,6 +133,14 @@ MaskApi.area = function( Rs )
   libmaskapi.rleArea(Qs,n,a:data())
   MaskApi._rlesFree(Qs,n)
   return a
+end
+
+MaskApi.invert = function( Rs )
+  local Qs, n, h, w = MaskApi._rlesFrLua(Rs)
+  local Ms = MaskApi._rlesInit(n)
+  libmaskapi.rleInvert(Qs[0],Ms[0],n)
+  MaskApi._rlesFree(Qs,n)
+  return MaskApi._rlesToLua(Ms,n)
 end
 
 MaskApi.toBbox = function( Rs )

--- a/LuaAPI/MaskApi.lua
+++ b/LuaAPI/MaskApi.lua
@@ -281,6 +281,7 @@ ffi.cdef[[
   void rleDecode( const RLE *R, byte *mask, siz n );
   void rleMerge( const RLE *R, RLE *M, siz n, int intersect );
   void rleArea( const RLE *R, siz n, uint *a );
+  void rleInvert( const RLE *R, RLE *M, siz n );
   void rleIou( RLE *dt, RLE *gt, siz m, siz n, byte *iscrowd, double *o );
   void rleNms( RLE *dt, siz n, uint *keep, double thr );
   void bbIou( BB dt, BB gt, siz m, siz n, byte *iscrowd, double *o );

--- a/MatlabAPI/MaskApi.m
+++ b/MatlabAPI/MaskApi.m
@@ -19,10 +19,10 @@ classdef MaskApi
   %
   % Many common operations on masks can be computed directly using the RLE
   % (without need for decoding). This includes computations such as area,
-  % union, intersection, etc. All of these operations are linear in the
-  % size of the RLE, in other words they are O(sqrt(n)) where n is the area
-  % of the object. Computing these operations on the original mask is O(n).
-  % Thus, using the RLE can result in substantial computational savings.
+  % union, intersection, inverse etc. All of these operations are linear in
+  % the size of the RLE, in other words they are O(sqrt(n)) where n is the
+  % area of the object. Computing these operations on the original mask is
+  % O(n). Thus, using the RLE can result in substantial computational savings.
   %
   % The following API functions are defined:
   %  encode - Encode binary masks using RLE.
@@ -31,6 +31,7 @@ classdef MaskApi
   %  iou    - Compute intersection over union between masks.
   %  nms    - Compute non-maximum suppression between ordered masks.
   %  area   - Compute area of encoded masks.
+  %  invert - Compute inverse of encoded masks.
   %  toBbox - Get bounding boxes surrounding encoded masks.
   %  frBbox - Convert bounding boxes to encoded masks.
   %  frPoly - Convert polygon to encoded mask.
@@ -42,6 +43,7 @@ classdef MaskApi
   %  o      = MaskApi.iou( dt, gt, [iscrowd=false] )
   %  keep   = MaskApi.nms( dt, thr )
   %  a      = MaskApi.area( Rs )
+  %  Rs     = MaskApi.invert( Rs )
   %  bbs    = MaskApi.toBbox( Rs )
   %  Rs     = MaskApi.frBbox( bbs, h, w )
   %  R      = MaskApi.frPoly( poly, h, w )
@@ -96,8 +98,16 @@ classdef MaskApi
       keep = maskApiMex('nms',dt',thr);
     end
     
+    function Rs_out = area( Rs )
+      Rs_out = maskApiMex( 'invert', Rs );
+    end
+    
     function a = area( Rs )
       a = maskApiMex( 'area', Rs );
+    end
+    
+    function Rs_out = invert( Rs )
+      Rs_out = maskApiMex( 'invert', Rs );
     end
     
     function bbs = toBbox( Rs )

--- a/MatlabAPI/MaskApi.m
+++ b/MatlabAPI/MaskApi.m
@@ -32,6 +32,7 @@ classdef MaskApi
   %  nms    - Compute non-maximum suppression between ordered masks.
   %  area   - Compute area of encoded masks.
   %  invert - Compute inverse of encoded masks.
+  %  crop   - Crop encoded masks to given bounding boxes.
   %  toBbox - Get bounding boxes surrounding encoded masks.
   %  frBbox - Convert bounding boxes to encoded masks.
   %  frPoly - Convert polygon to encoded mask.
@@ -44,6 +45,7 @@ classdef MaskApi
   %  keep   = MaskApi.nms( dt, thr )
   %  a      = MaskApi.area( Rs )
   %  Rs     = MaskApi.invert( Rs )
+  %  Rs     = MaskApi.crop( Rs, bbox )
   %  bbs    = MaskApi.toBbox( Rs )
   %  Rs     = MaskApi.frBbox( bbs, h, w )
   %  R      = MaskApi.frPoly( poly, h, w )
@@ -105,7 +107,11 @@ classdef MaskApi
     function Rs_out = invert( Rs )
       Rs_out = maskApiMex( 'invert', Rs );
     end
-    
+
+    function Rs_out = crop( Rs, bbox )
+      Rs_out = maskApiMex( 'crop', Rs, bbox );
+    end
+
     function bbs = toBbox( Rs )
       bbs = maskApiMex( 'toBbox', Rs )';
     end

--- a/MatlabAPI/MaskApi.m
+++ b/MatlabAPI/MaskApi.m
@@ -97,11 +97,7 @@ classdef MaskApi
     function keep = nms( dt, thr )
       keep = maskApiMex('nms',dt',thr);
     end
-    
-    function Rs_out = area( Rs )
-      Rs_out = maskApiMex( 'invert', Rs );
-    end
-    
+  
     function a = area( Rs )
       a = maskApiMex( 'area', Rs );
     end

--- a/MatlabAPI/private/maskApiMex.c
+++ b/MatlabAPI/private/maskApiMex.c
@@ -78,6 +78,10 @@ void mexFunction( int nl, mxArray *pl[], int nr, const mxArray *pr[] )
     pl[0]=mxCreateNumericMatrix(1,n,mxUINT32_CLASS,mxREAL);
     uint *a=(uint*) mxGetPr(pl[0]); rleArea(R,n,a);
     
+  } else if(!strcmp(action,"invert")) {
+    R=frMxArray(pr[0],&n,0);
+    RLE *M; rlesInit(&M,n); rleInvert(R,M,n); pl[0]=toMxArray(M,n);
+    
   } else if(!strcmp(action,"iou")) {
     if(nr>2) checkType(pr[2],mxUINT8_CLASS); siz nDt, nGt;
     byte *iscrowd = nr>2 ? (byte*) mxGetPr(pr[2]) : NULL;

--- a/PythonAPI/pycocotools/_mask.pyx
+++ b/PythonAPI/pycocotools/_mask.pyx
@@ -43,6 +43,7 @@ cdef extern from "maskApi.h":
     void rleDecode( const RLE *R, byte *mask, siz n )
     void rleMerge( const RLE *R, RLE *M, siz n, int intersect )
     void rleArea( const RLE *R, siz n, uint *a )
+    void rleInvert( const RLE *R_in, RLE *R_out, siz n )
     void rleIou( RLE *dt, RLE *gt, siz m, siz n, byte *iscrowd, double *o )
     void bbIou( BB dt, BB gt, siz m, siz n, byte *iscrowd, double *o )
     void rleToBbox( const RLE *R, BB bb, siz n )
@@ -166,6 +167,14 @@ def area(rleObjs):
     a = np.PyArray_SimpleNewFromData(1, shape, np.NPY_UINT32, _a)
     PyArray_ENABLEFLAGS(a, np.NPY_OWNDATA)
     return a
+
+def invert(rleObjs):
+    cdef RLEs Rs_in = _frString(rleObjs)
+    h, w, n = Rs_in._R[0].h, Rs_in._R[0].w, Rs_in._n
+    cdef RLEs Rs_out = RLEs(n)
+    rleInvert(Rs_in._R, Rs_out._R, n)
+    objs = _toString(Rs_out)
+    return objs
 
 # iou computation. support function overload (RLEs-RLEs and bbox-bbox).
 def iou( dt, gt, pyiscrowd ):

--- a/PythonAPI/pycocotools/mask.py
+++ b/PythonAPI/pycocotools/mask.py
@@ -1,5 +1,6 @@
 __author__ = 'tsungyi'
 
+import numpy as np
 import pycocotools._mask as _mask
 
 # Interface for manipulating masks stored in RLE format.
@@ -34,6 +35,7 @@ import pycocotools._mask as _mask
 #  iou            - Compute intersection over union between masks.
 #  area           - Compute area of encoded masks.
 #  invert         - Compute inverse of encoded masks.
+#  crop           - Crop encoded masks to given bounding boxes.
 #  toBbox         - Get bounding boxes surrounding encoded masks.
 #  frPyObjects    - Convert polygon, bbox, and uncompressed RLE to encoded RLE mask.
 #
@@ -44,6 +46,7 @@ import pycocotools._mask as _mask
 #  o      = iou( dt, gt, iscrowd )
 #  a      = area( Rs )
 #  Rs     = invert( Rs )
+#  Rs     = crop( Rs, bbox )
 #  bbs    = toBbox( Rs )
 #  Rs     = frPyObjects( [pyObjects], h, w )
 #
@@ -103,6 +106,14 @@ def invert(rleObjs):
         return _mask.invert(rleObjs)
     else:
         return _mask.invert([rleObjs])[0]
+
+def crop(rleObjs, bbox):
+    bbox = np.asanyarray(bbox, dtype=np.uint32)
+    if type(rleObjs) == list:
+        return _mask.crop(rleObjs, bbox)
+    else:
+        rleObjs_out = _mask.crop([rleObjs], bbox[np.newaxis])
+        return rleObjs_out[0]
 
 def toBbox(rleObjs):
     if type(rleObjs) == list:

--- a/PythonAPI/pycocotools/mask.py
+++ b/PythonAPI/pycocotools/mask.py
@@ -33,6 +33,7 @@ import pycocotools._mask as _mask
 #  merge          - Compute union or intersection of encoded masks.
 #  iou            - Compute intersection over union between masks.
 #  area           - Compute area of encoded masks.
+#  invert         - Compute inverse of encoded masks.
 #  toBbox         - Get bounding boxes surrounding encoded masks.
 #  frPyObjects    - Convert polygon, bbox, and uncompressed RLE to encoded RLE mask.
 #
@@ -42,6 +43,7 @@ import pycocotools._mask as _mask
 #  R      = merge( Rs, intersect=false )
 #  o      = iou( dt, gt, iscrowd )
 #  a      = area( Rs )
+#  Rs     = invert( Rs )
 #  bbs    = toBbox( Rs )
 #  Rs     = frPyObjects( [pyObjects], h, w )
 #
@@ -95,6 +97,12 @@ def area(rleObjs):
         return _mask.area(rleObjs)
     else:
         return _mask.area([rleObjs])[0]
+
+def invert(rleObjs):
+    if type(rleObjs) == list:
+        return _mask.invert(rleObjs)
+    else:
+        return _mask.invert([rleObjs])[0]
 
 def toBbox(rleObjs):
     if type(rleObjs) == list:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# About this fork
+
+Two extra features are available in my fork, for handling masks in runlength encoded format (RLE) without decoding and re-encoding:
+
+  - Mask inversion (background becomes foreground and vice versa)
+  - Cropping (mask is cropped to a specified box)
+
+# General info about the COCO API
 COCO API - http://cocodataset.org/
 
 COCO is a large image dataset designed for object detection, segmentation, person keypoints detection, stuff segmentation, and caption generation. This package provides Matlab, Python, and Lua APIs that assists in loading, parsing, and visualizing the annotations in COCO. Please visit http://cocodataset.org/ for more information on COCO, including for the data, paper, and tutorials. The exact format of the annotations is also described on the COCO website. The Matlab and Python APIs are complete, the Lua API provides only basic functionality.

--- a/common/maskApi.c
+++ b/common/maskApi.c
@@ -7,6 +7,7 @@
 #include "maskApi.h"
 #include <math.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 uint umin( uint a, uint b ) { return (a<b) ? a : b; }
 uint umax( uint a, uint b ) { return (a>b) ? a : b; }
@@ -75,8 +76,10 @@ void rleArea( const RLE *R, siz n, uint *a ) {
 }
 
 void rleInvert(const RLE *R, RLE *M, siz n) {
-  siz i, h=R[0].h, w=R[0].w; uint *cnts;
+  siz i, h, w; uint *cnts;
   for( i=0; i<n; i++ ) if (R[i].m) {
+    h=R[i].h;
+    w=R[i].w;
     if (R[i].cnts[0] == 0) {
       rleInit(M+i,h,w,R[i].m-1,R[i].cnts+1);
     } else {
@@ -84,6 +87,102 @@ void rleInvert(const RLE *R, RLE *M, siz n) {
       cnts[0]=0;
       memcpy(cnts+1,R[i].cnts,sizeof(uint)*R[i].m);
       (M + i)->cnts=cnts; (M + i)->h=h; (M + i)->w=w; (M + i)->m=R[i].m + 1;
+    }
+  }
+}
+
+void rleCrop( const RLE *R, RLE *M, siz n, const uint *bbox ) {
+  /* Crop RLEs to a specified bounding box.*/
+  for ( siz i=0; i<n; i++ ) {
+    uint h=R[i].h;
+    uint w=R[i].w;
+    siz m=R[i].m;
+
+    // Clip bbox to image boundary.
+    uint box_x_start=umin(bbox[i*4+0], w);
+    uint box_y_start=umin(bbox[i*4+1], h);
+    uint box_w=umin(bbox[i*4+2], w-box_x_start);
+    uint box_h=umin(bbox[i*4+3], h-box_y_start);
+
+    if ( m==0||box_w==0||box_h==0 ) {
+      // RLE is empty, so just fill in zeros.
+      rleInit(M+i, box_h, box_w, 0, NULL);
+      continue;
+    }
+    rleInit(M+i, box_h, box_w, R[i].m, R[i].cnts);
+
+    uint *cnts=M[i].cnts;
+    uint ignore_until=box_x_start*h+box_y_start;
+    uint final_use_until=(box_x_start+box_w-1)*h+box_h+box_y_start;
+    uint use_until=umin(ignore_until+box_h, final_use_until);
+
+    uint pos=0;
+    uint used_run_part=0;
+    bool ignoring=true;
+
+    for ( siz j=0; j<m; ) {
+      uint next_mode_switch=(ignoring ? ignore_until : use_until);
+      uint unused_run_part=cnts[j]-used_run_part;
+      uint step=umin(unused_run_part, next_mode_switch-pos);
+      pos+=step;
+
+      if ( ignoring ) {
+        // Consumed an ignored section, remove it.
+        cnts[j]-=step;
+      } else {
+        // Consumed a used section, tally it.
+        used_run_part+=step;
+      }
+
+      if ( step==unused_run_part ) {
+        // Reached the end of the current run, move to the next.
+        j++;
+        used_run_part=0; // Reinitialize the used run part for the next run.
+      }
+
+      if ( pos==next_mode_switch ) {
+        // Reached a bounding box boundary, switch modes.
+        if ( ignoring ) {
+          ignore_until+=h; // The next section will be one column away.
+        } else {
+          // The next section will be one column away or at the end of the box.
+          use_until=umin(use_until+h, final_use_until);
+          if ( pos==final_use_until ) {
+            // Reached the end of the bounding box, ignore until end of mask.
+            ignore_until=w*h;
+          }
+        }
+        // Toggle to the other mode.
+        ignoring=!ignoring;
+      }
+    }
+  }
+  // Remove non-initial empty runs, in order to make the RLE encoding valid.
+  rleEliminateZeroRuns(M, n);
+}
+
+
+void rleEliminateZeroRuns( RLE *R, siz n ) {
+  siz i, j, k;
+  for ( i=0; i<n; ++i ) {
+    if ( R[i].m==0 ) {
+      // Already empty.
+      continue;
+    }
+
+    for ( k=0, j=1; j<R[i].m; ++j ) {
+      if ( R[i].cnts[j]>0 ) {
+        R[i].cnts[++k]=R[i].cnts[j];
+      } else if ( j<R[i].m-1 ) {
+        R[i].cnts[k]+=R[i].cnts[++j];
+      }
+    }
+    if ( k==0&&R[i].cnts[0]==0 ) {
+      // Special case: a single run with length zero, so we can remove it altogether.
+      R[i].m=0;
+      rleFree(&R[i]);
+    } else {
+      R[i].m=k+1;
     }
   }
 }
@@ -243,3 +342,4 @@ void rleFrString( RLE *R, char *s, siz h, siz w ) {
   }
   rleInit(R,h,w,m,cnts); free(cnts);
 }
+

--- a/common/maskApi.c
+++ b/common/maskApi.c
@@ -74,6 +74,20 @@ void rleArea( const RLE *R, siz n, uint *a ) {
     a[i]=0; for( j=1; j<R[i].m; j+=2 ) a[i]+=R[i].cnts[j]; }
 }
 
+void rleInvert(const RLE *R, RLE *M, siz n) {
+  siz i, h=R[0].h, w=R[0].w; uint *cnts;
+  for( i=0; i<n; i++ ) if (R[i].m) {
+    if (R[i].cnts[0] == 0) {
+      rleInit(M+i,h,w,R[i].m-1,R[i].cnts+1);
+    } else {
+      cnts=malloc(sizeof(uint)*(R[i].m+1));
+      cnts[0]=0;
+      memcpy(cnts+1,R[i].cnts,sizeof(uint)*R[i].m);
+      (M + i)->cnts=cnts; (M + i)->h=h; (M + i)->w=w; (M + i)->m=R[i].m + 1;
+    }
+  }
+}
+
 void rleIou( RLE *dt, RLE *gt, siz m, siz n, byte *iscrowd, double *o ) {
   siz g, d; BB db, gb; int crowd;
   db=malloc(sizeof(double)*m*4); rleToBbox(dt,db,m);

--- a/common/maskApi.h
+++ b/common/maskApi.h
@@ -32,6 +32,9 @@ void rleMerge( const RLE *R, RLE *M, siz n, int intersect );
 /* Compute area of encoded masks. */
 void rleArea( const RLE *R, siz n, uint *a );
 
+/* Compute inverse of encoded masks. */
+void rleInvert( const RLE *R, RLE *M, siz n );
+
 /* Compute intersection over union between masks. */
 void rleIou( RLE *dt, RLE *gt, siz m, siz n, byte *iscrowd, double *o );
 

--- a/common/maskApi.h
+++ b/common/maskApi.h
@@ -35,6 +35,9 @@ void rleArea( const RLE *R, siz n, uint *a );
 /* Compute inverse of encoded masks. */
 void rleInvert( const RLE *R, RLE *M, siz n );
 
+/* Crop encoded masks. */
+void rleCrop( const RLE *R, RLE *M, siz n, const uint* bbox);
+
 /* Compute intersection over union between masks. */
 void rleIou( RLE *dt, RLE *gt, siz m, siz n, byte *iscrowd, double *o );
 
@@ -61,3 +64,6 @@ char* rleToString( const RLE *R );
 
 /* Convert from compressed string representation of encoded mask. */
 void rleFrString( RLE *R, char *s, siz h, siz w );
+
+/* Remove zero runlengths from RLE encoding, and sum up the neighbors accordingly. */
+void rleEliminateZeroRuns( RLE* R, siz n );


### PR DESCRIPTION
Currently only intersection and union are supported in runlength-encoded (RLE) representation. This is not a [functionally complete](https://en.wikipedia.org/wiki/Functional_completeness) set of Boolean operations. For example, currently there is no way to subtract one mask from another in RLE.

I've implemented **mask inversion** here, which is really simple in RLE representation: if the first runlength is zero then strip it off, otherwise prepend a zero.

Combined with intersection, this allows for implementing **any possible set operation in RLE**. For example, subtraction becomes subtract(a, b) = intersect(a, invert(b)).