### PR TITLE
make alignment consistent when result is -1.000 (has negative sign)

### DIFF
--- a/PythonAPI/pycocotools/cocoeval.py
+++ b/PythonAPI/pycocotools/cocoeval.py
@@ -426,7 +426,7 @@ class COCOeval:
         '''
         def _summarize( ap=1, iouThr=None, areaRng='all', maxDets=100 ):
             p = self.params
-            iStr = ' {:<18} {} @[ IoU={:<9} | area={:>6s} | maxDets={:>3d} ] = {:0.3f}'
+            iStr = ' {:<18} {} @[ IoU={:<9} | area={:>6s} | maxDets={:>3d} ] = {: 0.3f}'
             titleStr = 'Average Precision' if ap == 1 else 'Average Recall'
             typeStr = '(AP)' if ap==1 else '(AR)'
             iouStr = '{:0.2f}:{:0.2f}'.format(p.iouThrs[0], p.iouThrs[-1]) \


### PR DESCRIPTION
just a minor fix to an "issue" that triggered my OCD:

from this:
<img width="824" alt="image" src="https://user-images.githubusercontent.com/26622655/80235365-e5924080-8659-11ea-8b28-3a97b850c59c.png">

to this:
<img width="824" alt="image" src="https://user-images.githubusercontent.com/26622655/80235425-fcd12e00-8659-11ea-8650-df8cc8e24c24.png">