### PR TITLE
Make: Error Prevention

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,5 +11,5 @@ After downloading the images and annotations, run the Matlab, Python, or Lua dem
 
 To install:
 -For Matlab, add coco/MatlabApi to the Matlab path (OSX/Linux binaries provided)
--For Python, run "make" under coco/PythonAPI
+-For Python, run "make" under coco/PythonAPI (Cython package is required before you run "make")
 -For Lua, run “luarocks make LuaAPI/rocks/coco-scm-1.rockspec” under coco/


### PR DESCRIPTION
If you are using a fresh Python environment and don't have Cython package installed... running "make" inside PythonAPI folder returns the following

```gcc: error: pycocotools/_mask.c: No such file or directory
error: command 'gcc' failed with exit status 1
Makefile:3: recipe for target 'all' failed
make: *** [all] Error 1
```

Now, a quick google search would tell you to install Cython and doing so works. I know, it only takes a minute but I really think that adding this to the READMe is worth it. 