### PR TITLE
Load annotations from memory

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -68,11 +68,11 @@ def _isArrayLike(obj):
 
 
 class COCO:
-    def __init__(self, annotation_file=None):
+    def __init__(self, annotation_file=None, dataset=None):
         """
         Constructor of Microsoft COCO helper class for reading and visualizing annotations.
         :param annotation_file (str): location of annotation file
-        :param image_folder (str): location to the folder that hosts images.
+        :param dataset (bytes object): dynamic annotation file 
         :return:
         """
         # load dataset
@@ -82,8 +82,9 @@ class COCO:
             print('loading annotations into memory...')
             tic = time.time()
             dataset = json.load(open(annotation_file, 'r'))
-            assert type(dataset)==dict, 'annotation file format {} not supported'.format(type(dataset))
             print('Done (t={:0.2f}s)'.format(time.time()- tic))
+        if not dataset == None: 
+            assert type(dataset)==dict, 'annotation file format {} not supported'.format(type(dataset))
             self.dataset = dataset
             self.createIndex()
 

--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -72,7 +72,7 @@ class COCO:
         """
         Constructor of Microsoft COCO helper class for reading and visualizing annotations.
         :param annotation_file (str): location of annotation file
-        :param dataset (bytes object): dynamic annotation file 
+        :param dataset (bytes object): object with annotations, stored in memory
         :return:
         """
         # load dataset


### PR DESCRIPTION
The new functionality allows to load annotations from memory without having to upload an annotation file stored locally. Useful for dynamic datasets.