### PR TITLE
Properly close annotation file after loading the dataset using file o…

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -81,7 +81,8 @@ class COCO:
         if not annotation_file == None:
             print('loading annotations into memory...')
             tic = time.time()
-            dataset = json.load(open(annotation_file, 'r'))
+            with open(annotation_file, 'r') as f:
+                dataset = json.load(f)
             assert type(dataset)==dict, 'annotation file format {} not supported'.format(type(dataset))
             print('Done (t={:0.2f}s)'.format(time.time()- tic))
             self.dataset = dataset


### PR DESCRIPTION
This commit changes the pycocotools COCO() class annotation file loading by properly closing the annotation file after loading it using a file open context. 

This fixes an error when using tempfiles created by `tempfile.mkstemp()` as annotation files. As the annotation file is not closed correctly by the COCO class `__init__`, the program ends up in an inconsistent state when calling `os.close(fd)` to the tempfile file descriptor after the program is done with the COCO object. If new tempfiles are created after this and new COCO objects instantiated, the results seem to be undefined.

In any case, I believe that this commit makes the annotation file loading more 'pythonic' by properly closing the file after use.