### PR TITLE
Update cocoeval.py

### DIFF
--- a/PythonAPI/pycocotools/cocoeval.py
+++ b/PythonAPI/pycocotools/cocoeval.py
@@ -514,8 +514,8 @@ class Params:
         self.imgIds = []
         self.catIds = []
         # np.arange causes trouble.  the data point on arange is slightly larger than the true value
-        self.iouThrs = np.linspace(.5, 0.95, int(np.round((0.95 - .5) / .05)) + 1, endpoint=True)
-        self.recThrs = np.linspace(.0, 1.00, int(np.round((1.00 - .0) / .01)) + 1, endpoint=True)
+        self.iouThrs = np.linspace(.5, 0.95, int(np.around((0.95 - .5) / .05)).astype(int) + 1, endpoint=True)
+        self.recThrs = np.linspace(.0, 1.00, int(np.around((1.00 - .0) / .01)).astype(int) + 1, endpoint=True)
         self.maxDets = [20]
         self.areaRng = [[0 ** 2, 1e5 ** 2], [32 ** 2, 96 ** 2], [96 ** 2, 1e5 ** 2]]
         self.areaRngLbl = ['all', 'medium', 'large']


### PR DESCRIPTION
We found from numpy 1.19, the function `np.round()` equals to `np.around()`(although `np.round()` can still be used), but the returned type has changed from `np.int` to `np.float64`, which leads to `TypeError` raised from `np.linspace()`: "TypeError: 'numpy.float64' object cannot be interpreted as an integer".