### PR TITLE
Fix dependecy with numpy

### DIFF
--- a/PythonAPI/pyproject.toml
+++ b/PythonAPI/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]


### PR DESCRIPTION
Using PEP-508 avoid problems with `pip install`