### PR TITLE
COCOeval.summarize: allow arbitrary maxDets param

### DIFF
--- a/PythonAPI/pycocotools/cocoeval.py
+++ b/PythonAPI/pycocotools/cocoeval.py
@@ -172,7 +172,7 @@ class COCOeval:
             return []
         inds = np.argsort([-d['score'] for d in dt], kind='mergesort')
         dt = [dt[i] for i in inds]
-        if len(dt) > p.maxDets[-1]:
+        if p.maxDets[-1] and len(dt) > p.maxDets[-1]:
             dt=dt[0:p.maxDets[-1]]
 
         if p.iouType == 'segm':
@@ -196,7 +196,7 @@ class COCOeval:
         dts = self._dts[imgId, catId]
         inds = np.argsort([-d['score'] for d in dts], kind='mergesort')
         dts = [dts[i] for i in inds]
-        if len(dts) > p.maxDets[-1]:
+        if p.maxDets[-1] and len(dts) > p.maxDets[-1]:
             dts = dts[0:p.maxDets[-1]]
         # if len(gts) == 0 and len(dts) == 0:
         if len(gts) == 0 or len(dts) == 0:
@@ -424,13 +424,14 @@ class COCOeval:
         Compute and display summary metrics for evaluation results.
         Note this functin can *only* be applied on the default parameter setting
         '''
-        def _summarize( ap=1, iouThr=None, areaRng='all', maxDets=100 ):
+        def _summarize( ap=1, iouThr=None, areaRng='all', maxDets=None ):
             p = self.params
-            iStr = ' {:<18} {} @[ IoU={:<9} | area={:>6s} | maxDets={:>3d} ] = {:0.3f}'
+            iStr = ' {:<18} {} @[ IoU={:<9} | area={:>6s} | maxDets={:>3} ] = {:0.3f}'
             titleStr = 'Average Precision' if ap == 1 else 'Average Recall'
             typeStr = '(AP)' if ap==1 else '(AR)'
             iouStr = '{:0.2f}:{:0.2f}'.format(p.iouThrs[0], p.iouThrs[-1]) \
                 if iouThr is None else '{:0.2f}'.format(iouThr)
+            detStr = '{:d}'.format(maxDets) if maxDets else 'all'
 
             aind = [i for i, aRng in enumerate(p.areaRngLbl) if aRng == areaRng]
             mind = [i for i, mDet in enumerate(p.maxDets) if mDet == maxDets]
@@ -453,22 +454,22 @@ class COCOeval:
                 mean_s = -1
             else:
                 mean_s = np.mean(s[s>-1])
-            print(iStr.format(titleStr, typeStr, iouStr, areaRng, maxDets, mean_s))
+            print(iStr.format(titleStr, typeStr, iouStr, areaRng, detStr, mean_s))
             return mean_s
         def _summarizeDets():
             stats = np.zeros((12,))
             stats[0] = _summarize(1)
-            stats[1] = _summarize(1, iouThr=.5, maxDets=self.params.maxDets[2])
-            stats[2] = _summarize(1, iouThr=.75, maxDets=self.params.maxDets[2])
-            stats[3] = _summarize(1, areaRng='small', maxDets=self.params.maxDets[2])
-            stats[4] = _summarize(1, areaRng='medium', maxDets=self.params.maxDets[2])
-            stats[5] = _summarize(1, areaRng='large', maxDets=self.params.maxDets[2])
+            stats[1] = _summarize(1, iouThr=.5, maxDets=self.params.maxDets[-1])
+            stats[2] = _summarize(1, iouThr=.75, maxDets=self.params.maxDets[-1])
+            stats[3] = _summarize(1, areaRng='small', maxDets=self.params.maxDets[-1])
+            stats[4] = _summarize(1, areaRng='medium', maxDets=self.params.maxDets[-1])
+            stats[5] = _summarize(1, areaRng='large', maxDets=self.params.maxDets[-1])
             stats[6] = _summarize(0, maxDets=self.params.maxDets[0])
-            stats[7] = _summarize(0, maxDets=self.params.maxDets[1])
-            stats[8] = _summarize(0, maxDets=self.params.maxDets[2])
-            stats[9] = _summarize(0, areaRng='small', maxDets=self.params.maxDets[2])
-            stats[10] = _summarize(0, areaRng='medium', maxDets=self.params.maxDets[2])
-            stats[11] = _summarize(0, areaRng='large', maxDets=self.params.maxDets[2])
+            stats[7] = _summarize(0, maxDets=self.params.maxDets[1]) if len(self.params.maxDets) > 1 else -1
+            stats[8] = _summarize(0, maxDets=self.params.maxDets[2]) if len(self.params.maxDets) > 2 else -1
+            stats[9] = _summarize(0, areaRng='small', maxDets=self.params.maxDets[-1])
+            stats[10] = _summarize(0, areaRng='medium', maxDets=self.params.maxDets[-1])
+            stats[11] = _summarize(0, areaRng='large', maxDets=self.params.maxDets[-1])
             return stats
         def _summarizeKps():
             stats = np.zeros((10,))


### PR DESCRIPTION
This generalizes the AP summary output such that non-default values for the parameter **maxDets** become possible:

- upper boundary other than 100 (the default)
- intervals of different length than 3 (the default)
- `None` instead of fixed number for unlimited (which gets shown as `'all'`)

Here is an example output for `cocoeval.params.maxDets = [None]`:
```
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=all ] = 0.419
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=all ] = 0.468
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=all ] = 0.421
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=all ] = 0.183
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=all ] = 0.417
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=all ] = 0.028
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=all ] = 0.466
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=all ] = 0.187
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=all ] = 0.516
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=all ] = 0.045
```