### PR TITLE
process instances with same score in one step

### DIFF
--- a/PythonAPI/pycocotools/cocoeval.py
+++ b/PythonAPI/pycocotools/cocoeval.py
@@ -365,6 +365,7 @@ class COCOeval:
                     # mergesort is used to be consistent as Matlab implementation.
                     inds = np.argsort(-dtScores, kind='mergesort')
                     dtScoresSorted = dtScores[inds]
+                    _, uniq_inds = np.unique(dtScoresSorted, return_index=True)
 
                     dtm  = np.concatenate([e['dtMatches'][:,0:maxDet] for e in E], axis=1)[:,inds]
                     dtIg = np.concatenate([e['dtIgnore'][:,0:maxDet]  for e in E], axis=1)[:,inds]
@@ -380,6 +381,8 @@ class COCOeval:
                     for t, (tp, fp) in enumerate(zip(tp_sum, fp_sum)):
                         tp = np.array(tp)
                         fp = np.array(fp)
+                        tp = tp[uniq_inds]
+                        fp = fp[uniq_inds]
                         nd = len(tp)
                         rc = tp / npig
                         pr = tp / (fp+tp+np.spacing(1))


### PR DESCRIPTION
When computing points on the precision - recall curve instances with the same score should be processed in one step, not sequentially. If they have the same score there is no fixed order, but if they are processed sequentially the result depends on the order. In many typical use-cases this might not significant, however the fewer instances there are the higher the impact.