### PR TITLE
close files after reading

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -81,7 +81,8 @@ class COCO:
         if not annotation_file == None:
             print('loading annotations into memory...')
             tic = time.time()
-            dataset = json.load(open(annotation_file, 'r'))
+            with open(annotation_file, 'r', encoding='utf-8') as openFile:
+                dataset = json.load(openFile)
             assert type(dataset)==dict, 'annotation file format {} not supported'.format(type(dataset))
             print('Done (t={:0.2f}s)'.format(time.time()- tic))
             self.dataset = dataset
@@ -314,7 +315,8 @@ class COCO:
         print('Loading and preparing results...')
         tic = time.time()
         if type(resFile) == str or (PYTHON_VERSION == 2 and type(resFile) == unicode):
-            anns = json.load(open(resFile))
+            with open(resFile, 'r', encoding='utf-8') as openFile:
+                anns = json.load(openFile)
         elif type(resFile) == np.ndarray:
             anns = self.loadNumpyAnnotations(resFile)
         else:


### PR DESCRIPTION
Current implementation prints this warning:

> ResourceWarning: unclosed file <_io.TextIOWrapper name='/mnt/data/rbrown/Documents/Data/MONAI/LiveCell/livecell_coco_train.json' mode='r' encoding='UTF-8'>