### PR TITLE
Fix gt['ignore'] in cocoeval.py

### DIFF
--- a/PythonAPI/pycocotools/cocoeval.py
+++ b/PythonAPI/pycocotools/cocoeval.py
@@ -106,7 +106,7 @@ class COCOeval:
         # set ignore flag
         for gt in gts:
             gt['ignore'] = gt['ignore'] if 'ignore' in gt else 0
-            gt['ignore'] = 'iscrowd' in gt and gt['iscrowd']
+            gt['iscrowd'] = 'iscrowd' in gt and gt['iscrowd']
             if p.iouType == 'keypoints':
                 gt['ignore'] = (gt['num_keypoints'] == 0) or gt['ignore']
         self._gts = defaultdict(list)       # gt for evaluation


### PR DESCRIPTION
`ignore` should not depend on `iscrowd`

related issues:
https://github.com/cocodataset/cocoapi/pull/322#issuecomment-646385455
https://github.com/cocodataset/cocoapi/issues/123#issuecomment-389407300
https://github.com/open-mmlab/mmdetection/issues/9211#issuecomment-1513114793