### PR TITLE
Update coco.py

### DIFF
--- a/PythonAPI/pycocotools/coco.py
+++ b/PythonAPI/pycocotools/coco.py
@@ -64,7 +64,7 @@ elif PYTHON_VERSION == 3:
 
 
 def _isArrayLike(obj):
-    return hasattr(obj, '__iter__') and hasattr(obj, '__len__')
+    return hasattr(obj, '__iter__') and hasattr(obj, '__len__') and not isinstance(obj, str)
 
 
 class COCO:


### PR DESCRIPTION
Updated the `_isArrayLike` function to exclude strings from being considered array-like. This change ensures that string image IDs are correctly processed as single entities rather than sequences.